### PR TITLE
Fix edge case where scrolling through the channel list would cause lag

### DIFF
--- a/ChannelsPreview/ChannelsPreview.plugin.js
+++ b/ChannelsPreview/ChannelsPreview.plugin.js
@@ -3,7 +3,7 @@
  * @author arg0NNY
  * @authorId 224538553944637440
  * @invite M8DBtcZjXD
- * @version 1.4.1
+ * @version 1.4.2
  * @description Allows you to view recent messages in channels without switching to it.
  * @website https://github.com/arg0NNY/DiscordPlugins/tree/master/ChannelsPreview
  * @source https://raw.githubusercontent.com/arg0NNY/DiscordPlugins/master/ChannelsPreview/ChannelsPreview.plugin.js
@@ -21,7 +21,7 @@ module.exports = (() => {
                     "github_username": 'arg0NNY'
                 }
             ],
-            "version": "1.4.1",
+            "version": "1.4.2",
             "description": "Allows you to view recent messages in channels without switching to it.",
             github: "https://github.com/arg0NNY/DiscordPlugins/tree/master/ChannelsPreview",
             github_raw: "https://raw.githubusercontent.com/arg0NNY/DiscordPlugins/master/ChannelsPreview/ChannelsPreview.plugin.js"
@@ -31,7 +31,7 @@ module.exports = (() => {
                 "type": "fixed",
                 "title": "Fixed",
                 "items": [
-                    "Fixed popout not displaying due to Discord's changes."
+                    "Fixed potential lag while scrolling through direct messages when the mode was set to Mouse wheel click."
                 ]
             }
         ],
@@ -513,7 +513,7 @@ module.exports = (() => {
 
                         if (settings.trigger.displayOn !== 'mwheel') return;
                         setTimeout(() => {
-                            e.props.innerRef.current.onauxclick = e => e.preventDefault();
+                            if (e.props?.innerRef?.current) e.props.innerRef.current.onauxclick = e => e.preventDefault();
                         });
                     });
 

--- a/ChannelsPreview/README.md
+++ b/ChannelsPreview/README.md
@@ -18,6 +18,6 @@ Allows you to view recent messages in channels without switching to them.
 
 [channelspreview-download-link]: https://arg0nny.github.io/bd/download/?id=ChannelsPreview
 [channelspreview-view-link]: https://betterdiscord.app/plugin/ChannelsPreview
-[channelspreview-version-badge]: https://img.shields.io/badge/version-1.4.1-blue
+[channelspreview-version-badge]: https://img.shields.io/badge/version-1.4.2-blue
 [channelspreview-downloads-badge]: https://img.shields.io/badge/dynamic/json?color=brightgreen&label=downloads&query=%24%5B%3F%28%40.name%3D%3D%27ChannelsPreview%27%29%5D.downloads&url=https%3A%2F%2Fapi.betterdiscord.app%2Fv1%2Fstore%2Fplugins
 [channelspreview-likes-badge]: https://img.shields.io/badge/dynamic/json?color=green&label=likes&query=%24%5B%3F%28%40.name%3D%3D%27ChannelsPreview%27%29%5D.likes&url=https%3A%2F%2Fapi.betterdiscord.app%2Fv1%2Fstore%2Fplugins

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ SOFTWARE.
 
 [channelspreview-download-link]: https://arg0nny.github.io/bd/download/?id=ChannelsPreview
 [channelspreview-view-link]: https://betterdiscord.app/plugin/ChannelsPreview
-[channelspreview-version-badge]: https://img.shields.io/badge/version-1.4.1-blue
+[channelspreview-version-badge]: https://img.shields.io/badge/version-1.4.2-blue
 [channelspreview-downloads-badge]: https://img.shields.io/badge/dynamic/json?color=brightgreen&label=downloads&query=%24%5B%3F%28%40.name%3D%3D%27ChannelsPreview%27%29%5D.downloads&url=https%3A%2F%2Fapi.betterdiscord.app%2Fv1%2Fstore%2Fplugins
 [channelspreview-likes-badge]: https://img.shields.io/badge/dynamic/json?color=green&label=likes&query=%24%5B%3F%28%40.name%3D%3D%27ChannelsPreview%27%29%5D.likes&url=https%3A%2F%2Fapi.betterdiscord.app%2Fv1%2Fstore%2Fplugins
 


### PR DESCRIPTION
Fixed unnecessary errors while scrolling through direct messages with click mode set to Mouse Wheel. Yes, I may have been inspired by the normal channel case.